### PR TITLE
Migrate email storage to Supabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Byte-compiled files
+__pycache__/
+*.py[cod]
+
+# SQLite or CSV data files
+emails.csv
+emails.db
+

--- a/README.md
+++ b/README.md
@@ -1,23 +1,32 @@
 # AI Tailor Landing Page
 
-This repository contains a simple Flask application that serves a landing page for **AI Tailor**, a free personalized AI service. Visitors can join the waitlist by submitting their email address, which is stored in a local SQLite database.
+This repository contains a simple Flask application that serves a landing page for **AI Tailor**, a free personalized AI service. Visitors can join the waitlist by submitting their email address, which is stored in a Supabase table.
 
 ## Features
 
 - Modern responsive design using Bootstrap
 - Sign-up form to collect emails
-- Emails stored in `emails.db` using SQLite
+- Emails stored in Supabase
+- Admin routes to view and download collected addresses
 
 ## Requirements
 
 - Python 3.9+
 - `flask` package
+- `supabase` package
 
 Install dependencies:
 
 ```bash
-pip install Flask
+pip install Flask supabase
 ```
+
+## Configuration
+
+Set the following environment variables with your Supabase credentials before running the app:
+
+- `SUPABASE_URL` – your project URL
+- `SUPABASE_KEY` – service role or anon key with insert/select permissions
 
 ## Running the app
 
@@ -25,4 +34,4 @@ pip install Flask
 python app.py
 ```
 
-The application will run on <http://localhost:5000>. When a user submits their email, it will be saved in the `emails.db` database.
+The application will run on <http://localhost:5000>. Submitted emails are saved to your Supabase project and can be viewed at `/emails` or downloaded from `/download`.

--- a/app.py
+++ b/app.py
@@ -1,39 +1,72 @@
-from flask import Flask, render_template, request, redirect, url_for
-import sqlite3
+from flask import Flask, render_template, request, redirect, url_for, Response
 import os
+import csv
+import io
+from supabase import create_client, Client
 
 app = Flask(__name__)
-DATABASE = 'emails.db'
 
-def init_db():
-    conn = sqlite3.connect(DATABASE)
-    c = conn.cursor()
-    c.execute(
-        'CREATE TABLE IF NOT EXISTS emails (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT UNIQUE, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)'
-    )
-    conn.commit()
-    conn.close()
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
+SUPABASE_KEY = os.environ.get("SUPABASE_KEY")
 
-@app.route('/')
+supabase: Client | None = None
+if SUPABASE_URL and SUPABASE_KEY:
+    supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+
+def append_email(email: str) -> None:
+    """Insert a new email into the Supabase table."""
+    if not supabase:
+        return
+    supabase.table("emails").insert({"email": email}).execute()
+
+
+@app.route("/")
 def index():
-    return render_template('index.html')
+    return render_template("index.html")
 
-@app.route('/signup', methods=['POST'])
+
+@app.route("/signup", methods=["POST"])
 def signup():
-    email = request.form.get('email')
+    email = request.form.get("email")
     if email:
-        conn = sqlite3.connect(DATABASE)
-        c = conn.cursor()
-        c.execute('INSERT OR IGNORE INTO emails (email) VALUES (?)', (email,))
-        conn.commit()
-        conn.close()
-    return redirect(url_for('thanks'))
+        append_email(email)
+    return redirect(url_for("thanks"))
 
-@app.route('/thanks')
+
+@app.route("/thanks")
 def thanks():
-    return render_template('thanks.html')
+    return render_template("thanks.html")
 
-if __name__ == '__main__':
-    init_db()
-    port = int(os.environ.get('PORT', 5000))
-    app.run(host='0.0.0.0', port=port)
+
+@app.route("/emails")
+def list_emails():
+    if not supabase:
+        return "Supabase not configured", 500
+    res = supabase.table("emails").select("email,created_at").execute()
+    emails = res.data or []
+    return render_template("emails.html", emails=emails)
+
+
+@app.route("/download")
+def download_emails():
+    if not supabase:
+        return "Supabase not configured", 500
+    res = supabase.table("emails").select("email,created_at").execute()
+    rows = res.data or []
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["email", "created_at"])
+    for row in rows:
+        writer.writerow([row.get("email"), row.get("created_at")])
+    output.seek(0)
+    return Response(
+        output.getvalue(),
+        mimetype="text/csv",
+        headers={"Content-Disposition": "attachment; filename=emails.csv"},
+    )
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host="0.0.0.0", port=port)

--- a/templates/emails.html
+++ b/templates/emails.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Email List - AI Tailor</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+    <div class="container mt-5">
+        <h1 class="mb-4">Collected Emails</h1>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Email</th>
+                    <th>Created At</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in emails %}
+                <tr>
+                    <td>{{ row.email }}</td>
+                    <td>{{ row.created_at }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <a class="btn btn-primary" href="{{ url_for('download_emails') }}">Download CSV</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- switch application storage from SQLite to Supabase
- add a new Supabase client and helper functions
- create `/emails` and `/download` endpoints backed by Supabase
- document environment variables and install steps
- ignore local data files

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685afcce2e4883269e24fda6facc33d9